### PR TITLE
Use v1.0 of "Bump to v1.0" as release-pr title if one of prs has such title

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See: https://developer.github.com/v3/pulls/#get-a-single-pull-request
 
 ### Pull request titles
 
-If one of pull requests of which consist a release pull request has a title like "Bump to v1.0", the title of the release pull request becomes "v1.0". Otherwise, it uses timestamps like "Release 2000-01-01 00:00:00" in local timezone.
+If one of pull requests of which consist a release pull request has a title like "Bump to v1.0", the title of the release pull request becomes "Release v1.0". Otherwise, it uses timestamps like "Release 2000-01-01 00:00:00" in local timezone.
 
 ## Install
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ release(config).then(function (pullRequest) {
 
 See: https://developer.github.com/v3/pulls/#get-a-single-pull-request
 
+### Pull request titles
+
+If one of pull requests of which consist a release pull request has a title like "Bump to v1.0", the title of the release pull request becomes "v1.0". Otherwise, it uses timestamps like "Release 2000-01-01 00:00:00" in local timezone.
+
 ## Install
 ```
 npm install github-pr-release

--- a/lib/release-message.js
+++ b/lib/release-message.js
@@ -2,7 +2,16 @@ var render = require('mustache').render
 var moment = require('moment')
 
 module.exports = function releaseMessage (template, prs) {
-  var text = render(template, { now: moment().format('YYYY-MM-DD HH:mm:ss'), prs: prs })
+  var title = null
+  for (var pr of prs) {
+    const m = pr.title.match(/Bump to (.*)/)
+    if (m) {
+      title = m[1]
+      break;
+    }
+  }
+
+  var text = render(template, { title: title, now: moment().format('YYYY-MM-DD HH:mm:ss'), prs: prs })
   var lines = text.split('\n')
   var title = lines[0]
   var body = lines.slice(1)

--- a/lib/release-message.js
+++ b/lib/release-message.js
@@ -2,16 +2,16 @@ var render = require('mustache').render
 var moment = require('moment')
 
 module.exports = function releaseMessage (template, prs) {
-  var title = null
+  var version = moment().format('YYYY-MM-DD HH:mm:ss')
   for (var pr of prs) {
     const m = pr.title.match(/Bump to (.*)/)
     if (m) {
-      title = m[1]
-      break;
+      version = m[1]
+      break
     }
   }
 
-  var text = render(template, { title: title, now: moment().format('YYYY-MM-DD HH:mm:ss'), prs: prs })
+  var text = render(template, { version: version, prs: prs })
   var lines = text.split('\n')
   var title = lines[0]
   var body = lines.slice(1)

--- a/lib/release-message.js
+++ b/lib/release-message.js
@@ -4,7 +4,7 @@ var moment = require('moment')
 module.exports = function releaseMessage (template, prs) {
   var version = moment().format('YYYY-MM-DD HH:mm:ss')
   for (var pr of prs) {
-    const m = pr.title.match(/Bump to (.*)/)
+    const m = pr.title.match(/Bump to (.*)/i)
     if (m) {
       version = m[1]
       break

--- a/release.mustache
+++ b/release.mustache
@@ -1,4 +1,9 @@
+{{#title}}
+{{title}}
+{{/title}}
+{{^title}}
 Release {{now}}
+{{/title}}
 {{#prs}}
 - [ ] #{{number}} {{title}} {{#assignee}}@{{login}}{{/assignee}}{{^assignee}}{{#user}}@{{login}}{{/user}}{{/assignee}}
 {{/prs}}

--- a/release.mustache
+++ b/release.mustache
@@ -1,9 +1,4 @@
-{{#title}}
-{{title}}
-{{/title}}
-{{^title}}
-Release {{now}}
-{{/title}}
+Release {{version}}
 {{#prs}}
 - [ ] #{{number}} {{title}} {{#assignee}}@{{login}}{{/assignee}}{{^assignee}}{{#user}}@{{login}}{{/user}}{{/assignee}}
 {{/prs}}


### PR DESCRIPTION
If a project uses explicit version numbers and those version numbers are updated with pull requests, titled like "Bump to v1.0", it is great to have release pr with title "Release v1.0" instead of "Release 2015-07-28 18:35:47".
