### PR TITLE
GithubClient#prepareReleasePR should rejects on unexpected error responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ module.exports = (robot) ->
     release(config).then((pullRequest) ->
       msg.send pullRequest.html_url
     )
+    .catch((err) ->
+      msg.send("Create release PR failed: " + err.message)
+    )
 ```
 
 ## License

--- a/lib/github-client.js
+++ b/lib/github-client.js
@@ -85,6 +85,10 @@ GithubClient.prototype.prepareReleasePR = function () {
     if (res.statusCode === 201) {
       return res.body
     } else if (res.statusCode === 422) {
+      var errMessage = res.body.errors[0].message
+      if (!errMessage.match(/pull request already exists/)) {
+        return Promise.reject(new Error(errMessage))
+      }
       return self.get(self.pullRequestEndpoint(), {
         base: self.base,
         head: self.head,

--- a/test/github-client.js
+++ b/test/github-client.js
@@ -38,7 +38,17 @@ describe('GithubClient', function () {
     describe('when pr already exists', function () {
       nock('https://api.github.com/')
         .post('/repos/uiureo/awesome-app/pulls')
-        .reply(422)
+        .reply(422, {
+          message: 'Validation Failed',
+          errors: [
+            {
+              resource: 'PullRequest',
+              code: 'custom',
+              message: 'A pull request already exists for uiureo:master.'
+            }
+          ],
+          documentation_url: 'https://developer.github.com/v3/pulls/#create-a-pull-request'
+        })
 
       nock('https://api.github.com/')
         .get('/repos/uiureo/awesome-app/pulls')
@@ -52,6 +62,29 @@ describe('GithubClient', function () {
           assert(pr.number === 3)
           done()
         }).catch(done)
+      })
+    })
+
+    describe('when no changes between head and base', function () {
+      nock('https://api.github.com/')
+        .post('/repos/uiureo/awesome-app/pulls')
+        .reply(422, {
+          message: 'Validation Failed',
+          errors: [
+            {
+              resource: 'PullRequest',
+              code: 'custom',
+              message: 'No commits between production and master'
+            }
+          ],
+          documentation_url: 'https://developer.github.com/v3/pulls/#create-a-pull-request'
+        })
+
+      it('rejects with error message', function (done) {
+        this.client.prepareReleasePR().catch(function (error) {
+          assert(error.message === 'No commits between production and master')
+          done()
+        })
       })
     })
   })


### PR DESCRIPTION
With this change we can handle unexpected errors of POST pulls API call.

For example with hubot script:
```coffee
release = require('github-pr-release')
module.exports = (robot) ->
  robot.respond /release/i, (msg) ->
    release(config).then((pullRequest) ->
      msg.send pullRequest.html_url
    )
    .catch((err) ->
      msg.send("Create release PR failed: " + err.message)
    )
```

```
> hubot release
> Create release PR failed: No commits between production and master
```