### PR TITLE
Enable to prefer author's username to assignee's one of each PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ release(config).then(function (pullRequest) {
 
 See: https://developer.github.com/v3/pulls/#get-a-single-pull-request
 
+#### Optional config
+
+If you set `preferAuthor` to `true`, then not assignee's username but author's one will be written into the message of the release pull request.
+
+``` javascript
+var config = {
+  // ...
+  preferAuthor: true
+}
+```
 ### Pull request titles
 
 If one of pull requests of which consist a release pull request has a title like "Bump to v1.0", the title of the release pull request becomes "Release v1.0". Otherwise, it uses timestamps like "Release 2000-01-01 00:00:00" in local timezone.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function createReleasePR (config) {
   return client.prepareReleasePR().then(function (releasePR) {
     return client.collectReleasePRs(releasePR).then(function (prs) {
       var template = fs.readFileSync(__dirname + '/release.mustache', 'utf8')
-      var message = releaseMessage(template, prs)
+      var message = releaseMessage(template, prs, !!config.preferAuthor)
 
       return client.updatePR(releasePR, message)
     })

--- a/lib/release-message.js
+++ b/lib/release-message.js
@@ -1,7 +1,7 @@
 var render = require('mustache').render
 var moment = require('moment')
 
-module.exports = function releaseMessage (template, prs) {
+module.exports = function releaseMessage (template, prs, preferAuthor) {
   var version = moment().format('YYYY-MM-DD HH:mm:ss')
 
   prs.some(function (pr) {
@@ -13,7 +13,7 @@ module.exports = function releaseMessage (template, prs) {
     }
   })
 
-  var text = render(template, { version: version, prs: prs })
+  var text = render(template, { version: version, prs: prs, preferAuthor: preferAuthor })
   var lines = text.split('\n')
   var title = lines[0]
   var body = lines.slice(1)

--- a/release.mustache
+++ b/release.mustache
@@ -1,4 +1,11 @@
 Release {{version}}
+{{#preferAuthor}}
+{{#prs}}
+- [ ] #{{number}} {{title}} {{#user}}@{{login}}{{/user}}
+{{/prs}}
+{{/preferAuthor}}
+{{^preferAuthor}}
 {{#prs}}
 - [ ] #{{number}} {{title}} {{#assignee}}@{{login}}{{/assignee}}{{^assignee}}{{#user}}@{{login}}{{/user}}{{/assignee}}
 {{/prs}}
+{{/preferAuthor}}


### PR DESCRIPTION
This PR enables to prefer **author** to **assignee** for the username written into the message of the release PR.

If config has `preferAuthor` as `true`, author's username will be used.

``` javascript
var config = {
  // ...
  preferAuthor: true
}
```

Thanks.